### PR TITLE
pick compiler based on perl config

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use Config;
 
 use Alien::Base::ModuleBuild;
 
@@ -22,7 +23,7 @@ my $builder = Alien::Base::ModuleBuild->new(
         exact_filename => 'samtools-0.1.19.tar.bz2',
         exact_version  => '0.1.19',
     },
-    alien_build_commands   => ['make lib CFLAGS="-fPIC -g -Wall -O2"'],
+    alien_build_commands   => ["make lib CC=$Config{cc} CFLAGS=\"-fPIC -g -Wall -O2\""],
     alien_install_commands => [
         'mkdir -p %s/lib',
         'cp libbam.a %s/lib',


### PR DESCRIPTION
This should fix #1 

My Perl is on Linux, but it too uses clang and I verified that it built with clang instead of gcc.
