### PR TITLE
use AB::MB as configure_requires

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -11,7 +11,7 @@ my $builder = Alien::Base::ModuleBuild->new(
     configure_requires => { 'Alien::Base' => 0, },
     requires           => {
         'perl'        => '5.8.1',
-        'Alien::Base' => 0,
+        'Alien::Base::ModuleBuild' => 0,
     },
     dist_author      => 'George Hartzell <hartzell@cpan.org>',
     alien_name       => 'samtools',


### PR DESCRIPTION
This will correct the configure_requires to specify `Alien::Base::ModuleBuild` instead of `Alien::Base`.  For the rationale for this change, please see https://github.com/Perl5-Alien/Alien-Base/issues/157
